### PR TITLE
Fixes for multithreading and for running without proof production

### DIFF
--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -832,7 +832,7 @@ void Internal::analyze () {
   }
 
   // Build the chain proof for the conflict.
-  build_chain ();
+  if (internal->proof) build_chain ();
 
   // Update actual size statistics.
   //

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -375,15 +375,6 @@ struct analyze_trail_larger {
 // Fill the 'chain' variable with the LRAT style unit propagation proof of
 // newly learnt clause
 
-//static vector<signed char> justified;
-static vector<Clause*> old_reasons;
-struct stack_element {
-    int lit;
-    int64_t id;
-    const_literal_iterator begin, end;
-};
-static vector<stack_element> justify_todo;
-
 bool justify_lit (Internal& s, int lit) {
   Flags & f = s.flags (lit);
   if (f.justified) return true;
@@ -394,7 +385,7 @@ bool justify_lit (Internal& s, int lit) {
   } else {
     const Clause* c = v.reason;
     if (c) {
-        justify_todo.push_back({lit, c->id, c->begin (), c->end ()});
+        s.justify_todo.push_back({lit, c->id, c->begin (), c->end ()});
         return false;
     } else {
       // LOG ("PROOF justify %d hyp", lit);

--- a/src/analyze.cpp
+++ b/src/analyze.cpp
@@ -413,7 +413,7 @@ void Internal::build_chain () {
           auto& el = justify_todo.back ();
           while (el.begin != el.end) {
               int lit2 = *el.begin++;
-              if (el.lit != lit2 && !justify_lit (*this, lit2)) goto next;
+              if (el.lit != lit2 && !justify_lit (*this, -lit2)) goto next;
           }
           chain.push_back (el.id);
           flags (el.lit).justified = true;

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -230,6 +230,12 @@ struct Internal {
   };
   vector<stack_element> justify_todo;
 
+  // Dominik Schreiber 2022-12-15:
+  // Required fields previously defined as static fields
+  // in the head of propagate.cpp.
+  Clause decision_reason_clause;
+  Clause * decision_reason = &decision_reason_clause;
+
   /*----------------------------------------------------------------------*/
 
   // Asynchronous termination flag written by 'terminate' and read by

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -221,6 +221,15 @@ struct Internal {
   // TODO Replace with something more robust.
   int64_t last_direct_import_unit_id;
 
+  // Dominik Schreiber 2022-12-14:
+  // Required by stack implementation of "justify_lit" (analyze.cpp).
+  struct stack_element {
+      int lit;
+      int64_t id;
+      const_literal_iterator begin, end;
+  };
+  vector<stack_element> justify_todo;
+
   /*----------------------------------------------------------------------*/
 
   // Asynchronous termination flag written by 'terminate' and read by

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -57,12 +57,12 @@ OPTION( covermaxeff,     1e8,  0,2e9,1,0,1, "maximum cover efficiency") \
 OPTION( coverminclslim,    4,  2,2e9,0,0,1, "minimum clause size") \
 OPTION( covermineff,     1e6,  0,2e9,1,0,1, "minimum cover efficiency") \
 OPTION( coverreleff,       4,  1,1e5,1,0,1, "relative efficiency per mille") \
-OPTION( decompose,         0,  0,  1,0,1,1, "decompose BIG in SCCs and ELS")  /* FIX: 0 */ \
+OPTION( decompose,         1,  0,  1,0,1,1, "decompose BIG in SCCs and ELS")  /* FIX: 0 */ \
 OPTION( decomposerounds,   2,  1, 16,1,0,1, "number of decompose rounds") \
 OPTION( deduplicate,       1,  0,  1,0,1,1, "remove duplicated binary clauses") \
 OPTION( eagersubsume,      1,  0,  1,0,0,1, "subsume recently learned") \
 OPTION( eagersubsumelim,  20,  1,1e3,0,0,1, "limit on subsumed candidates") \
-OPTION( elim,              0,  0,  1,0,1,1, "bounded variable elimination")  /* FIX: 0 */ \
+OPTION( elim,              1,  0,  1,0,1,1, "bounded variable elimination")  /* FIX: 0 */ \
 OPTION( elimands,          1,  0,  1,0,0,1, "find AND gates") \
 OPTION( elimaxeff,       2e9,  0,2e9,1,0,1, "maximum elimination efficiency") \
 OPTION( elimbackward,      1,  0,  1,0,0,1, "eager backward subsumption") \
@@ -108,7 +108,7 @@ OPTION( minimize,          1,  0,  1,0,0,1, "minimize learned clauses") \
 OPTION( minimizedepth,   1e3,  0,1e3,0,0,1, "minimization depth") \
 OPTION( num_original_clauses,0,0,2e9,0,0,1, "number of clauses in the problem") \
 OPTION( phase,             1,  0,  1,0,0,1, "initial phase") \
-OPTION( probe,             0,  0,  1,0,1,1, "failed literal probing" ) /* FIX: 0 */ \
+OPTION( probe,             1,  0,  1,0,1,1, "failed literal probing" ) /* FIX: 0 */ \
 OPTION( probehbr,          1,  0,  1,0,0,1, "learn hyper binary clauses") \
 OPTION( probeint,        5e3,  1,2e9,0,0,1, "probing interval" ) \
 OPTION( probemaxeff,     1e8,  0,2e9,1,0,1, "maximum probing efficiency") \
@@ -167,7 +167,7 @@ OPTION( subsumereleff,   1e3,  1,1e5,1,0,1, "relative efficiency per mille") \
 OPTION( subsumestr,        1,  0,  1,0,0,1, "strengthen during subsume") \
 OPTION( target,            1,  0,  2,0,0,1, "target phases (1=stable only)") \
 OPTION( terminateint,     10,  0,1e4,0,0,1, "termination check interval") \
-OPTION( ternary,           0,  0,  1,0,1,1, "hyper ternary resolution")   /* FIX: 0 */ \
+OPTION( ternary,           1,  0,  1,0,1,1, "hyper ternary resolution")   /* FIX: 0 */ \
 OPTION( ternarymaxadd,   1e3,  0,1e4,1,0,1, "maximum clauses added in percent") \
 OPTION( ternarymaxeff,   1e8,  0,2e9,1,0,1, "ternary maximum efficiency") \
 OPTION( ternarymineff,   1e6,  1,2e9,1,0,1, "minimum ternary efficiency") \
@@ -175,12 +175,12 @@ OPTION( ternaryocclim,   1e2,  1,2e9,2,0,1, "ternary occurrence limit") \
 OPTION( ternaryreleff,    10,  1,1e5,1,0,1, "relative efficiency in per mille") \
 OPTION( ternaryrounds,     2,  1, 16,1,0,1, "maximum ternary rounds") \
 OPTION( total_instances,   1,  1,2e9,0,0,0, "total number of solver instances running on the problem") \
-OPTION( transred,          0,  0,  1,0,1,1, "transitive reduction of BIG")  /* FIX: 0 */ \
+OPTION( transred,          1,  0,  1,0,1,1, "transitive reduction of BIG")  /* FIX: 0 */ \
 OPTION( transredmaxeff,  1e8,  0,2e9,1,0,1, "maximum efficiency") \
 OPTION( transredmineff,  1e6,  0,2e9,1,0,1, "minimum efficiency") \
 OPTION( transredreleff,  1e2,  1,1e5,1,0,1, "relative efficiency per mille") \
 QUTOPT( verbose,           0,  0,  3,0,0,0, "more verbose messages") \
-OPTION( vivify,            0,  0,  1,0,1,1, "vivification")  /* FIX: 0 */ \
+OPTION( vivify,            1,  0,  1,0,1,1, "vivification")  /* FIX: 0 */ \
 OPTION( vivifymaxeff,    1e8,  0,2e9,1,0,1, "maximum efficiency") \
 OPTION( vivifymineff,    1e5,  0,2e9,1,0,1, "minimum efficiency") \
 OPTION( vivifyonce,        0,  0,  2,0,0,1, "vivify once: 1=red, 2=red+irr") \

--- a/src/propagate.cpp
+++ b/src/propagate.cpp
@@ -15,8 +15,7 @@ namespace CaDiCaL {
 // a zero pointer as reason.  Now only units have a zero reason and
 // decisions need to use the pseudo reason 'decision_reason'.
 
-static Clause decision_reason_clause;
-static Clause * decision_reason = &decision_reason_clause;
+// D.S. 2022-12-15: Moved static fields to be non-static members of Internal
 
 // If chronological backtracking is used the actual assignment level might
 // be lower than the current decision level. In this case the assignment

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -841,6 +841,14 @@ bool Solver::trace_proof (const char * path) {
   File * internal_file = File::write (internal, path);
   bool res = (internal_file != 0);
   internal->trace (internal_file);
+  // disable options which don't work together with LRAT proof tracing
+  bool ok;
+  ok = set("decompose", 0); assert(ok);
+  ok = set("elim", 0); assert(ok);
+  ok = set("probe", 0); assert(ok);
+  ok = set("ternary", 0); assert(ok);
+  ok = set("transred", 0); assert(ok);
+  ok = set("vivify", 0); assert(ok);
   LOG_API_CALL_RETURNS ("trace_proof", path, res);
   return res;
 }

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -720,7 +720,7 @@ void Solver::connect_learner (Learner * learner) {
 #endif
   external->learner = learner;
   LearnerObserver *lo = new LearnerObserver (external);
-  external->internal->proof->connect(lo);
+  if (external->internal->proof) external->internal->proof->connect(lo);
   LOG_API_CALL_END ("connect_learner");
 }
 


### PR DESCRIPTION
A few fixes from my side:

* The stack-based implementation of `justify_lit` is incorrect for multithreaded use and leads to crashes since it uses a static variable. I moved it to be a member of `Internal`.
* Attempting to run the solver in Mallob *without* proof production lead to crashes due to nullptrs. I fixed these problems since I'd like to be able to use the same Mallob build for solving formulas with and without proof production.
* In the same vein, the LRAT-unsafe options are now disabled in the call to `Solver::trace_proof` instead of being disabled by default, which results in the "full" configuration if run without proof production.

I might find some more fixes related to running this version without proof production after some more rigorous testing.